### PR TITLE
Frontload the report names

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,11 +339,11 @@ through the file:// protocol.
 #### File export settings
 
 * `--output-html-report=<file>`    Save HTML report into that file. Set to empty '' to disable HTML report. By default
-  saved into `tmp/report.%domain%.%datetime%.html`.
+  saved into `tmp/%domain%.report.%datetime%.html`.
 * `--output-json-file=<file>`      File path for JSON output. Set to empty '' to disable JSON file. By default saved
- into `tmp/output.%domain%.%datetime%.json`.
+ into `tmp/%domain%.output.%datetime%.json`.
 * `--output-text-file=<file>`      File path for TXT output. Set to empty '' to disable TXT file. By default saved
-  into `tmp/output.%domain%.%datetime%.txt`.
+  into `tmp/%domain%.output.%datetime%.txt`.
 
 #### Mailer options
 

--- a/src/Crawler/Export/FileExporter.php
+++ b/src/Crawler/Export/FileExporter.php
@@ -139,9 +139,9 @@ class FileExporter extends BaseExporter implements Exporter
         $options->addGroup(new Group(
             self::GROUP_FILE_EXPORT_SETTINGS,
             'File export settings', [
-            new Option('--output-html-report', null, 'outputHtmlReport', Type::FILE, false, "Save HTML report into that file. Set to empty '' to disable HTML report.", 'tmp/report.%domain%.%datetime%.html', true),
-            new Option('--output-json-file', null, 'outputJsonFile', Type::FILE, false, "Save report as JSON. Set to empty '' to disable JSON report.", 'tmp/output.%domain%.%datetime%.json', true),
-            new Option('--output-text-file', null, 'outputTextFile', Type::FILE, false, "Save output as TXT. Set to empty '' to disable TXT report.", 'tmp/output.%domain%.%datetime%.txt', true),
+            new Option('--output-html-report', null, 'outputHtmlReport', Type::FILE, false, "Save HTML report into that file. Set to empty '' to disable HTML report.", 'tmp/%domain%.report.%datetime%.html', true),
+            new Option('--output-json-file', null, 'outputJsonFile', Type::FILE, false, "Save report as JSON. Set to empty '' to disable JSON report.", 'tmp/%domain%.output.%datetime%.json', true),
+            new Option('--output-text-file', null, 'outputTextFile', Type::FILE, false, "Save output as TXT. Set to empty '' to disable TXT report.", 'tmp/%domain%.output.%datetime%.txt', true),
             new Option('--add-host-to-output-file', null, 'addHostToOutputFile', Type::BOOL, false, 'Append initial URL host to filename except sitemaps.', false, false),
             new Option('--add-timestamp-to-output-file', null, 'addTimestampToOutputFile', Type::BOOL, false, 'Append timestamp to filename except sitemaps.', false, false),
         ]));


### PR DESCRIPTION
This PR changes the filename of the reports so that the domain name comes first. As most default directory listings are sorted by alpha by default this way all the reports for a domain will be grouped together.

## Before
![image](https://github.com/janreges/siteone-crawler/assets/1296369/be2def66-7a5a-4131-a91d-fd59d6621637)

## After
![image](https://github.com/janreges/siteone-crawler/assets/1296369/ff765894-abe4-441a-a7c3-db5a16c1a981)
