### PR TITLE
New option for the OfflineWebsiteExporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ If necessary, you can also use your own endpoint `--upload-to` for saving the HT
 
 * `--offline-export-dir=<dir>`     Path to directory where to save the offline version of the website. If target directory does not exist, crawler will try to create it (requires sufficient rights).
 * `--offline-export-store-only-url-regex=<regex>` For debug - when filled it will activate debug mode and store only URLs which match one of these PCRE regexes. Can be specified multiple times.
+* `--ignore-store-file-error` Enable this option to ignore any file storing errors. The export process will continue.
 
 #### Sitemap options
 

--- a/src/Crawler/Export/OfflineWebsiteExporter.php
+++ b/src/Crawler/Export/OfflineWebsiteExporter.php
@@ -43,6 +43,8 @@ class OfflineWebsiteExporter extends BaseExporter implements Exporter
      */
     protected array $offlineExportStoreOnlyUrlRegex = [];
 
+    protected bool $ignoreStoreFileError = false;
+
     /**
      * For debug only - storage of debug messages if debug mode is activated (storeOnlyUrls)
      * @var array|null
@@ -163,9 +165,10 @@ class OfflineWebsiteExporter extends BaseExporter implements Exporter
         }
 
         if ($saveFile && @file_put_contents($storeFilePath, $content) === false) {
-            // throw exception only if file has extension (handle edge-cases as <img src="/icon/hash/"> and response is SVG)
+            // throw exception if file has extension (handle edge-cases as <img src="/icon/hash/"> and response is SVG)
             $exceptionOnError = preg_match('/\.[a-z0-9\-]{1,15}$/i', $storeFilePath) === 1;
-            if ($exceptionOnError) {
+            // AND if the exception should NOT be ignored
+            if ($exceptionOnError && !$this->ignoreStoreFileError) {
                 throw new Exception("Cannot store file '$storeFilePath'.");
             } else {
                 $message = "Cannot store file '$storeFilePath' (undefined extension). Original URL: {$visitedUrl->url}";
@@ -258,6 +261,7 @@ class OfflineWebsiteExporter extends BaseExporter implements Exporter
             'Offline exporter options', [
             new Option('--offline-export-dir', '-oed', 'offlineExportDirectory', Type::DIR, false, 'Path to directory where to save the offline version of the website.', null, true),
             new Option('--offline-export-store-only-url-regex', null, 'offlineExportStoreOnlyUrlRegex', Type::REGEX, true, 'For debug - when filled it will activate debug mode and store only URLs which match one of these PCRE regexes. Can be specified multiple times.', null, true),
+            new Option('--ignore-store-file-error', null, 'ignoreStoreFileError', Type::BOOL, false, 'Ignores any file storing errors. The export process will continue.', false, false),
         ]));
         return $options;
     }


### PR DESCRIPTION
Hello,

I came over an issue during export of a website that has images with very long file names. Because of the length they could not be saved on my filesystem. Additionally the whole offline export stopped because of the following thrown exception:
https://github.com/janreges/siteone-crawler/blob/9798252901dd25797d1d38fa26a19c6dbc409fa1/src/Crawler/Export/OfflineWebsiteExporter.php#L169

This exception quits the for loop:
https://github.com/janreges/siteone-crawler/blob/9798252901dd25797d1d38fa26a19c6dbc409fa1/src/Crawler/Export/OfflineWebsiteExporter.php#L84-L93

Therefore, I added an option to `OfflineWebsiteExporter` that ignores such errors: `--ignore-store-file-error`
If it is set, the above exception won't be thrown.