### PR TITLE
wip: regex improvements (supporting spaces), convert to lowercase support, proper empty query string support

### DIFF
--- a/src/Crawler/ContentProcessor/HtmlProcessor.php
+++ b/src/Crawler/ContentProcessor/HtmlProcessor.php
@@ -272,6 +272,44 @@ class HtmlProcessor extends BaseProcessor implements ContentProcessor
         $foundUrls->addUrlsFromTextArray($matches[1], $sourceUrlWithoutFragment, FoundUrl::SOURCE_LINK_HREF);
     }
 
+    private function pregMatchUrls(string $html, string $pattern_start, string $pattern_match, string $pattern_end, bool $unquoted = true, ?array &$all_matches = null): array
+    { 
+        $all_matches = [[], []];
+        $urls = [];
+        $patterns = [];
+        $pattern_template = '/' . str_replace('/', '\/', $pattern_start) . "{{quote}}({{not_quote}}" . str_replace('/', '\/', $pattern_match) . "){{quote}}" . str_replace('/', '\/', $pattern_end) . '/is';
+        
+        $pattern = str_replace(['{{quote}}', '{{quote_space}}', '{{not_quote}}'], ['"', '', ''], $pattern_template);
+        $patterns[] = $pattern;
+        preg_match_all($pattern, $html, $matches);
+        if (!empty($matches[1])) {
+            $urls = array_merge($urls, $matches[1]);
+            $all_matches = array_map('array_merge', $all_matches, $matches);
+        }
+        
+        $pattern = str_replace(['{{quote}}', '{{quote_space}}', '{{not_quote}}'], ['\'', '', ''], $pattern_template);
+        $patterns[] = $pattern;
+        preg_match_all($pattern, $html, $matches);
+        if (!empty($matches[1])) {
+            $urls = array_merge($urls, $matches[1]);
+            $all_matches = array_map('array_merge', $all_matches, $matches);
+        }
+
+        if ($unquoted) {
+            $pattern = str_replace(['{{quote}}', '{{quote_space}}', '{{not_quote}}'], ['', ' ', '[^"\']'], $pattern_template);
+            $patterns[] = $pattern;
+            preg_match_all($pattern, $html, $matches);
+            if (!empty($matches[1])) {
+                $urls = array_merge($urls, $matches[1]);
+                $all_matches = array_map('array_merge', $all_matches, $matches);
+            }
+        }
+
+        // print_r($patterns);
+        // print_r($all_matches);
+        return $urls;
+    }
+
     /**
      * @param string $html
      * @param ParsedUrl $sourceUrl
@@ -283,24 +321,24 @@ class HtmlProcessor extends BaseProcessor implements ContentProcessor
         $sourceUrlWithoutFragment = $sourceUrl->getFullUrl(true, false);
 
         // <img src="..."
-        preg_match_all('/<img\s+[^>]*?src=["\']?([^"\'> ]+)["\']?[^>]*>/is', $html, $matches);
-        $foundUrls->addUrlsFromTextArray($matches[1], $sourceUrlWithoutFragment, FoundUrl::SOURCE_IMG_SRC);
+        $urls = $this->pregMatchUrls($html, '<img\s+[^>]*?src=', '[^{{quote}}{{quote_space}}>]+', '[^>]*>');
+        $foundUrls->addUrlsFromTextArray($urls, $sourceUrlWithoutFragment, FoundUrl::SOURCE_IMG_SRC);
 
         // <input src="..."
-        preg_match_all('/<input\s+[^>]*?src=["\']?([^"\'> ]+\.[a-z0-9]{1,10})["\']?[^>]*>/is', $html, $matches);
-        $foundUrls->addUrlsFromTextArray($matches[1], $sourceUrlWithoutFragment, FoundUrl::SOURCE_INPUT_SRC);
+        $urls = $this->pregMatchUrls($html, '<input\s+[^>]*?src=', '[^{{quote}}{{quote_space}}>]+', '[^>]*>');
+        $foundUrls->addUrlsFromTextArray($urls, $sourceUrlWithoutFragment, FoundUrl::SOURCE_INPUT_SRC);
 
         // <link href="...(png|gif|jpg|jpeg|webp|avif|tif|bmp|svg)"
-        preg_match_all('/<link\s+[^>]*?href=["\']?([^"\'> ]+\.(png|gif|jpg|jpeg|webp|avif|tif|bmp|svg|ico)(|\?[^"\' ]))["\']?[^>]*>/is', $html, $matches);
-        $foundUrls->addUrlsFromTextArray($matches[1], $sourceUrlWithoutFragment, FoundUrl::SOURCE_LINK_HREF);
+        $urls = $this->pregMatchUrls($html, '<link\s+[^>]*?href=', '[^{{quote}}{{quote_space}}>]+\.(?:png|gif|jpe?g|webp|avif|tiff?|bmp|svg|ico)(?:\?[^{{quote}}{{quote_space}}\>]*)?', '(?=[\s>])[^>]*>');
+        $foundUrls->addUrlsFromTextArray($urls, $sourceUrlWithoutFragment, FoundUrl::SOURCE_LINK_HREF);
 
         // <source src="..."
-        preg_match_all('/<source\s+[^>]*?src=["\']([^"\'>]+)["\'][^>]*>/is', $html, $matches);
-        $foundUrls->addUrlsFromTextArray($matches[1], $sourceUrlWithoutFragment, FoundUrl::SOURCE_SOURCE_SRC);
+        $urls = $this->pregMatchUrls($html, '<source\s+[^>]*?href=', '[^{{quote}}{{quote_space}}>]+', '[^>]*>');
+        $foundUrls->addUrlsFromTextArray($urls, $sourceUrlWithoutFragment, FoundUrl::SOURCE_SOURCE_SRC);
 
         // CSS url()
-        preg_match_all("/url\s*\(\s*['\"]?([^'\")]+\.(jpg|jpeg|png|gif|bmp|tif|webp|avif)[^'\")]*)['\"]?\s*\)/is", $html, $matches);
-        $foundUrls->addUrlsFromTextArray($matches[1], $sourceUrlWithoutFragment, FoundUrl::SOURCE_CSS_URL);
+        $urls = $this->pregMatchUrls($html, 'url\s*\(\s*', '[^{{quote}}{{quote_space}}\)]+\.(?:png|gif|jpe?g|webp|avif|tiff?|bmp|svg|ico)(?:\?[^{{quote}}{{quote_space}}\)]*)?', '(?=[\s\)])[^\)]*\)');
+        $foundUrls->addUrlsFromTextArray($urls, $sourceUrlWithoutFragment, FoundUrl::SOURCE_CSS_URL);
 
         // <picture><source srcset="..."><img src="..."></picture>
         // <img srcset="..."
@@ -406,15 +444,15 @@ class HtmlProcessor extends BaseProcessor implements ContentProcessor
      */
     private function findStylesheets(string $html, ParsedUrl $sourceUrl, FoundUrls $foundUrls): void
     {
-        preg_match_all('/<link\s+[^>]*?href=["\']([^"\']+)["\'][^>]*>/is', $html, $matches);
-        foreach ($matches[0] as $key => $match) {
+        $this->pregMatchUrls($html, '<link\s+[^>]*?href=', '[^{{quote}}{{quote_space}}>]+', '[^>]*>', false, $all_matches);
+        foreach ($all_matches[0] as $key => $match) {
             if (stripos($match, 'rel=') !== false && stripos($match, 'stylesheet') === false) {
-                unset($matches[0][$key]);
-                unset($matches[1][$key]);
+                unset($all_matches[0][$key]);
+                unset($all_matches[1][$key]);
             }
         }
 
-        $foundUrls->addUrlsFromTextArray($matches[1], $sourceUrl->getFullUrl(true, false), FoundUrl::SOURCE_LINK_HREF);
+        $foundUrls->addUrlsFromTextArray($all_matches[1], $sourceUrl->getFullUrl(true, false), FoundUrl::SOURCE_LINK_HREF);
     }
 
     /**

--- a/src/Crawler/ContentProcessor/HtmlProcessor.php
+++ b/src/Crawler/ContentProcessor/HtmlProcessor.php
@@ -219,9 +219,10 @@ class HtmlProcessor extends BaseProcessor implements ContentProcessor
      */
     private function findHrefUrls(string $html, ParsedUrl $sourceUrl, FoundUrls $foundUrls, string $regexForHtmlExtensions): void
     {
-        preg_match_all('/<a[^>]*\shref=["\']?([^#][^"\'\s>]+)["\'\s]?[^>]*>/is', $html, $matches);
-        $foundUrlsTxt = $matches[1];
+        $urls = $this->matchUrlsRegex($html, '/<a[^>]*\shref={{quote}}((?!#){{no_quote}}[^{{quote}}{{quote_space}}>]+){{quote}}[^>]*>/is');
+        $foundUrlsTxt = $urls;
 
+        // TODO: Document what this is trying to do before converting it to ->matchUrlsRegex
         preg_match_all('/href\\\\["\'][:=]\\\\["\'](https?:\/\/[^"\'\\\\]+)\\\\["\']/i', $html, $matches);
         $foundUrlsTxt = array_merge($foundUrlsTxt, $matches[1] ?? []);
 
@@ -263,41 +264,140 @@ class HtmlProcessor extends BaseProcessor implements ContentProcessor
     {
         $sourceUrlWithoutFragment = $sourceUrl->getFullUrl(true, false);
 
-        // CSS @font-face
-        preg_match_all("/url\s*\(\s*['\"]?([^'\"\s>]+\.(eot|ttf|woff2|woff|otf)[^'\")]*)['\"]?\s*\)/is", $html, $matches);
-        $foundUrls->addUrlsFromTextArray($matches[1], $sourceUrlWithoutFragment, FoundUrl::SOURCE_CSS_URL);
+        // CSS @font-face        
+        $urls = $this->matchUrlsRegex($html, '/url\s*\(\s*{{quote}}({{no_quote}}[^{{quote}}{{quote_space}}\)]+\.{{extensions:eot|ttf|woff2?|otf}}){{quote_assert:\)}}[^\)]*\)/is');
+        $foundUrls->addUrlsFromTextArray($urls, $sourceUrlWithoutFragment, FoundUrl::SOURCE_CSS_URL);
 
         // <link href="...(eot|ttf|woff2|woff|otf)
-        preg_match_all('/<link\s+[^>]*href=["\']?([^"\' ]+\.(eot|ttf|woff2|woff|otf)[^"\' ]*)["\']?[^>]*>/is', $html, $matches);
-        $foundUrls->addUrlsFromTextArray($matches[1], $sourceUrlWithoutFragment, FoundUrl::SOURCE_LINK_HREF);
+        $urls = $this->matchUrlsRegex($html, '/<link\s+[^>]*href={{quote}}({{no_quote}}[^{{quote}}{{quote_space}}>]+\.{{extensions:eot|ttf|woff2?|otf}}){{quote_assert:>}}[^>]*>/is');
+        $foundUrls->addUrlsFromTextArray($urls, $sourceUrlWithoutFragment, FoundUrl::SOURCE_LINK_HREF);
     }
 
-    private function pregMatchUrls(string $html, string $pattern_start, string $pattern_match, string $pattern_end, bool $unquoted = true, ?array &$all_matches = null): array
-    { 
+
+    /**
+     * Matches URLs in HTML using a pseudo regex template language that handles quoted and unquoted attributes.
+     *
+     * This method implements a powerful pseudo regex template system that automatically generates multiple
+     * regex patterns to handle different quoting scenarios (double quotes, single quotes, and unquoted values).
+     * It's specifically designed for extracting URLs from HTML attributes where the quoting style may vary.
+     *
+     * **Pseudo Regex Template Language:**
+     *
+     * The template uses special placeholders that get replaced with appropriate regex patterns:
+     *
+     * - `{{quote}}` - The actual quote character (", ', or empty for unquoted)
+     * - `{{quote_space}}` - Conditional space: empty for quoted, space for unquoted scenarios
+     * - `{{no_quote}}` - Conditional negation: empty for quoted, [^"'] for unquoted scenarios
+     * - `{{extensions:<extensions>}}` - Expands to (?:<extensions>)(?:\?[^{{quote}}{{quote_space}}>]*)?
+     * - `{{quote_assert:<chars>}}` - Expands to {{quote}}(?=[\s<chars>])
+     *
+     * **How it works:**
+     * 1. The method processes macro placeholders first ({{extensions:}} and {{quote_assert:}})
+     * 2. Then generates 2-3 regex patterns by replacing quote placeholders:
+     *    - Pattern 1: Double quotes ({{quote}} = ", {{quote_space}} = "", {{no_quote}} = "")
+     *    - Pattern 2: Single quotes ({{quote}} = ', {{quote_space}} = "", {{no_quote}} = "")
+     *    - Pattern 3: Unquoted ({{quote}} = "", {{quote_space}} = " ", {{no_quote}} = "[^\"']") - only if $unquoted=true
+     * 3. Executes all patterns and merges results
+     *
+     * **Key Insight - Conditional Replacements:**
+     * The `{{no_quote}}` and `{{quote_space}}` placeholders enable conditional behavior:
+     * - For quoted attributes: they become empty, so patterns only avoid the quote character
+     * - For unquoted attributes: they add restrictions to handle space-separated values
+     *
+     * Example: `[^{{quote}}{{quote_space}}>]` becomes:
+     * - `[^">]` for quoted (avoids quote and >)
+     * - `[^"' >]` for unquoted (avoids quotes, spaces, and >)
+     *
+     * @param string $html The HTML content to search in
+     * @param string $pattern_template The pseudo regex template with {{placeholders}}
+     * @param bool $unquoted Whether to include unquoted attribute matching (default: true)
+     * @param array|null $all_matches Reference to store all regex matches (optional)
+     * @return array Array of matched URLs (from capture group 1)
+     *
+     * @example Basic href extraction:
+     * ```php
+     * $urls = $this->matchUrlsRegex($html,
+     *     '/<a[^>]*\shref={{quote}}((?!#){{no_quote}}[^{{quote}}{{quote_space}}>]+){{quote}}[^>]*>/is'
+     * );
+     * // Matches: <a href="url">, <a href='url'>, <a href=url>
+     * // The [^{{quote}}{{quote_space}}>] part becomes:
+     * // - [^">] for quoted (stops at quote or >)
+     * // - [^"' >] for unquoted (stops at quotes, space, or >)
+     * ```
+     *
+     * @example CSS url() with file extensions:
+     * ```php
+     * $urls = $this->matchUrlsRegex($html,
+     *     '/url\s*\(\s*{{quote}}({{no_quote}}[^{{quote}}{{quote_space}}\)]+\.{{extensions:eot|ttf|woff2?|otf}}){{quote_assert:\)}}[^\)]*\)/is'
+     * );
+     * // Matches: url("font.woff"), url('font.ttf'), url(font.eot)
+     * // {{extensions:eot|ttf|woff2?|otf}} expands to: (?:eot|ttf|woff2?|otf)(?:\?[^{{quote}}{{quote_space}}>]*)?
+     * // {{quote_assert:\)}} expands to: {{quote}}(?=[\s\)])
+     * ```
+     *
+     * @example Image src with quote assertion:
+     * ```php
+     * $urls = $this->matchUrlsRegex($html,
+     *     '/<img\s+[^>]*?src={{quote}}({{no_quote}}[^{{quote}}{{quote_space}}>]+){{quote}}[^>]*>/is'
+     * );
+     * // Matches: <img src="image.jpg">, <img src='image.png'>, <img src=image.gif>
+     * ```
+     *
+     * **Generated Patterns Example:**
+     * Template: `href={{quote}}({{no_quote}}[^{{quote}}{{quote_space}}>]+){{quote}}`
+     *
+     * Generates:
+     * - `href="([^">]+)"` (double quotes - {{no_quote}} empty, {{quote_space}} empty)
+     * - `href='([^'>]+)'` (single quotes - {{no_quote}} empty, {{quote_space}} empty)
+     * - `href=([^"'][^"' >]+)` (unquoted - {{no_quote}} = [^"'], {{quote_space}} = space)
+     *
+     * **Use Cases:**
+     * - Extracting href URLs from <a> tags
+     * - Finding src URLs in <img>, <script>, <source> tags
+     * - Parsing CSS url() declarations
+     * - Extracting font file URLs with specific extensions
+     * - Any scenario where HTML attributes may be quoted or unquoted
+     */
+    private function matchUrlsRegex(string $html, string $pattern_template, bool $unquoted = true, ?array &$all_matches = null): array
+    {
         $all_matches = [[], []];
         $urls = [];
         $patterns = [];
-        $pattern_template = '/' . str_replace('/', '\/', $pattern_start) . "{{quote}}({{not_quote}}" . str_replace('/', '\/', $pattern_match) . "){{quote}}" . str_replace('/', '\/', $pattern_end) . '/is';
-        
-        $pattern = str_replace(['{{quote}}', '{{quote_space}}', '{{not_quote}}'], ['"', '', ''], $pattern_template);
-        $patterns[] = $pattern;
-        preg_match_all($pattern, $html, $matches);
-        if (!empty($matches[1])) {
-            $urls = array_merge($urls, $matches[1]);
-            $all_matches = array_map('array_merge', $all_matches, $matches);
-        }
-        
-        $pattern = str_replace(['{{quote}}', '{{quote_space}}', '{{not_quote}}'], ['\'', '', ''], $pattern_template);
-        $patterns[] = $pattern;
-        preg_match_all($pattern, $html, $matches);
-        if (!empty($matches[1])) {
-            $urls = array_merge($urls, $matches[1]);
-            $all_matches = array_map('array_merge', $all_matches, $matches);
+
+        // Process macro placeholders first
+        $pattern_template = preg_replace_callback('/{{extensions:([^}]+)}}/', function ($matches) {
+            return '(?:'. $matches[1] . ')(?:\?[^{{quote}}{{quote_space}}\>]*)?';
+        }, $pattern_template);
+
+        $pattern_template = preg_replace_callback('/{{quote_assert:([^}]+)}}/', function ($matches) {
+            return '{{quote}}(?=[\s' . $matches[1] . '])';
+        }, $pattern_template);
+
+        $pattern_variables = [
+            '{{quote}}',
+            '{{quote_space}}',
+            '{{no_quote}}',
+        ];
+
+        $quotes_replacements = [
+            ['', '', ''],
+        ];
+
+        if (strstr($pattern_template, '{{quote}}') !== false) {
+            $quotes_replacements = [
+                ['"', '', ''],
+                ["'", '', ''],
+            ];
+
+            if ($unquoted) {
+                $quotes_replacements[] = ['', ' ', '[^"\']'];
+            }
         }
 
-        if ($unquoted) {
-            $pattern = str_replace(['{{quote}}', '{{quote_space}}', '{{not_quote}}'], ['', ' ', '[^"\']'], $pattern_template);
+        foreach ($quotes_replacements as $replacement) {
+            $pattern = str_replace($pattern_variables, $replacement, $pattern_template);
             $patterns[] = $pattern;
+
             preg_match_all($pattern, $html, $matches);
             if (!empty($matches[1])) {
                 $urls = array_merge($urls, $matches[1]);
@@ -305,8 +405,6 @@ class HtmlProcessor extends BaseProcessor implements ContentProcessor
             }
         }
 
-        // print_r($patterns);
-        // print_r($all_matches);
         return $urls;
     }
 
@@ -321,23 +419,23 @@ class HtmlProcessor extends BaseProcessor implements ContentProcessor
         $sourceUrlWithoutFragment = $sourceUrl->getFullUrl(true, false);
 
         // <img src="..."
-        $urls = $this->pregMatchUrls($html, '<img\s+[^>]*?src=', '[^{{quote}}{{quote_space}}>]+', '[^>]*>');
+        $urls = $this->matchUrlsRegex($html, '/<img\s+[^>]*?src={{quote}}({{no_quote}}[^{{quote}}{{quote_space}}>]+){{quote}}[^>]*>/is');
         $foundUrls->addUrlsFromTextArray($urls, $sourceUrlWithoutFragment, FoundUrl::SOURCE_IMG_SRC);
 
         // <input src="..."
-        $urls = $this->pregMatchUrls($html, '<input\s+[^>]*?src=', '[^{{quote}}{{quote_space}}>]+', '[^>]*>');
+        $urls = $this->matchUrlsRegex($html, '/<input\s+[^>]*?src={{quote}}({{no_quote}}[^{{quote}}{{quote_space}}>]+){{quote}}[^>]*>/is');
         $foundUrls->addUrlsFromTextArray($urls, $sourceUrlWithoutFragment, FoundUrl::SOURCE_INPUT_SRC);
 
         // <link href="...(png|gif|jpg|jpeg|webp|avif|tif|bmp|svg)"
-        $urls = $this->pregMatchUrls($html, '<link\s+[^>]*?href=', '[^{{quote}}{{quote_space}}>]+\.(?:png|gif|jpe?g|webp|avif|tiff?|bmp|svg|ico)(?:\?[^{{quote}}{{quote_space}}\>]*)?', '(?=[\s>])[^>]*>');
+        $urls = $this->matchUrlsRegex($html, '/<link\s+[^>]*?href={{quote}}({{no_quote}}[^{{quote}}{{quote_space}}>]+\.(?:png|gif|jpe?g|webp|avif|tiff?|bmp|svg|ico)(?:\?[^{{quote}}{{quote_space}}\>]*)?){{quote}}(?=[\s>])[^>]*>/is');
         $foundUrls->addUrlsFromTextArray($urls, $sourceUrlWithoutFragment, FoundUrl::SOURCE_LINK_HREF);
 
         // <source src="..."
-        $urls = $this->pregMatchUrls($html, '<source\s+[^>]*?href=', '[^{{quote}}{{quote_space}}>]+', '[^>]*>');
+        $urls = $this->matchUrlsRegex($html, '/<source\s+[^>]*?src={{quote}}({{no_quote}}[^{{quote}}{{quote_space}}>]+){{quote}}[^>]*>/is');
         $foundUrls->addUrlsFromTextArray($urls, $sourceUrlWithoutFragment, FoundUrl::SOURCE_SOURCE_SRC);
 
         // CSS url()
-        $urls = $this->pregMatchUrls($html, 'url\s*\(\s*', '[^{{quote}}{{quote_space}}\)]+\.(?:png|gif|jpe?g|webp|avif|tiff?|bmp|svg|ico)(?:\?[^{{quote}}{{quote_space}}\)]*)?', '(?=[\s\)])[^\)]*\)');
+        $urls = $this->matchUrlsRegex($html, '/url\s*\(\s*{{quote}}({{no_quote}}[^{{quote}}{{quote_space}}\)]+\.(?:png|gif|jpe?g|webp|avif|tiff?|bmp|svg|ico)(?:\?[^{{quote}}{{quote_space}}\)]*)?){{quote}}(?=[\s\)])[^\)]*\)/is');
         $foundUrls->addUrlsFromTextArray($urls, $sourceUrlWithoutFragment, FoundUrl::SOURCE_CSS_URL);
 
         // <picture><source srcset="..."><img src="..."></picture>
@@ -444,7 +542,7 @@ class HtmlProcessor extends BaseProcessor implements ContentProcessor
      */
     private function findStylesheets(string $html, ParsedUrl $sourceUrl, FoundUrls $foundUrls): void
     {
-        $this->pregMatchUrls($html, '<link\s+[^>]*?href=', '[^{{quote}}{{quote_space}}>]+', '[^>]*>', false, $all_matches);
+        $this->matchUrlsRegex($html, '/<link\s+[^>]*?href={{quote}}({{no_quote}}[^{{quote}}{{quote_space}}>]+){{quote}}[^>]*>/is', false, $all_matches);
         foreach ($all_matches[0] as $key => $match) {
             if (stripos($match, 'rel=') !== false && stripos($match, 'stylesheet') === false) {
                 unset($all_matches[0][$key]);

--- a/src/Crawler/Export/OfflineWebsiteExporter.php
+++ b/src/Crawler/Export/OfflineWebsiteExporter.php
@@ -60,6 +60,12 @@ class OfflineWebsiteExporter extends BaseExporter implements Exporter
     protected bool $ignoreStoreFileError = false;
 
     /**
+     * Convert all filenames to lowercase for offline export
+     * @var bool
+     */
+    protected bool $offlineExportLowercase = false;
+
+    /**
      * Replace HTML/JS/CSS content with `xxx -> bbb` or regexp in PREG format: `/card[0-9]/ -> card`
      *
      * @var string[]
@@ -102,6 +108,9 @@ class OfflineWebsiteExporter extends BaseExporter implements Exporter
 
         // user-defined replaceQueryString will deactivate replacing query string with hash and use custom replacement
         OfflineUrlConverter::setReplaceQueryString($this->replaceQueryString);
+
+        // set lowercase option for all URL conversions
+        OfflineUrlConverter::setLowercase($this->offlineExportLowercase);
 
         // filter only relevant URLs with OK status codes
         $exportedUrls = array_filter($visitedUrls, function (VisitedUrl $visitedUrl) {
@@ -195,7 +204,7 @@ class OfflineWebsiteExporter extends BaseExporter implements Exporter
         // same logic is in method convertUrlToRelative()
         $storeFilePath = sprintf('%s/%s',
             $this->offlineExportDirectory,
-            OfflineUrlConverter::sanitizeFilePath($this->getRelativeFilePathForFileByUrl($visitedUrl), false)
+            OfflineUrlConverter::sanitizeFilePath($this->getRelativeFilePathForFileByUrl($visitedUrl), false, $this->offlineExportLowercase)
         );
 
         $directoryPath = dirname($storeFilePath);
@@ -282,7 +291,7 @@ class OfflineWebsiteExporter extends BaseExporter implements Exporter
             $visitedUrl->contentType === Crawler::CONTENT_TYPE_ID_IMAGE ? 'src' : 'href'
         );
 
-        $relativeUrl = $urlConverter->convertUrlToRelative(false);
+        $relativeUrl = $urlConverter->convertUrlToRelative(false, $this->offlineExportLowercase);
         $relativeTargetUrl = $urlConverter->getRelativeTargetUrl();
         $relativePath = '';
 
@@ -335,6 +344,7 @@ class OfflineWebsiteExporter extends BaseExporter implements Exporter
             new Option('--offline-export-no-auto-redirect-html', null, 'offlineExportNoAutoRedirectHtml', Type::BOOL, false, "Disable automatic creation of redirect HTML files for subfolders that contain an index.html file. This solves situations for URLs where sometimes the URL ends with a slash, sometimes it doesn't.", false, false),
             new Option('--replace-content', null, 'replaceContent', Type::REPLACE_CONTENT, true, "Replace HTML/JS/CSS content with `foo -> bar` or regexp in PREG format: `/card[0-9]/i -> card`", null, true, true),
             new Option('--replace-query-string', null, 'replaceQueryString', Type::REPLACE_CONTENT, true, "Instead of using a short hash instead of a query string in the filename, just replace some characters. You can use simple format 'foo -> bar' or regexp in PREG format, e.g. '/([a-z]+)=([^&]*)(&|$)/i -> $1__$2'", null, true, true),
+            new Option('--offline-export-lowercase', null, 'offlineExportLowercase', Type::BOOL, false, 'Convert all filenames to lowercase for offline export. Useful for case-insensitive filesystems.', false, false),
             new Option('--ignore-store-file-error', null, 'ignoreStoreFileError', Type::BOOL, false, 'Ignores any file storing errors. The export process will continue.', false, false),
         ]));
         return $options;

--- a/src/Crawler/Export/Utils/OfflineUrlConverter.php
+++ b/src/Crawler/Export/Utils/OfflineUrlConverter.php
@@ -26,6 +26,7 @@ class OfflineUrlConverter
     private readonly array $callbackIsExternalDomainAllowedForCrawling;
 
     private static array $replaceQueryString = [];
+    private static bool $lowercase = false;
 
     private TargetDomainRelation $targetDomainRelation;
 
@@ -58,9 +59,10 @@ class OfflineUrlConverter
 
     /**
      * @param bool $keepFragment
+     * @param bool $lowercase
      * @return string
      */
-    public function convertUrlToRelative(bool $keepFragment = true): string
+    public function convertUrlToRelative(bool $keepFragment = true, bool $lowercase = false): string
     {
         $forcedUrl = $this->getForcedUrlIfNeeded();
         if ($forcedUrl) {
@@ -71,7 +73,11 @@ class OfflineUrlConverter
         $this->calculateAndApplyDepth();
 
         $preFinalUrl = $this->relativeTargetUrl->getFullUrl(false, $keepFragment);
-        return self::sanitizeFilePath($preFinalUrl, $keepFragment);
+
+        // Use static lowercase setting if no explicit parameter provided
+        $useLowercase = $lowercase || self::$lowercase;
+
+        return self::sanitizeFilePath($preFinalUrl ?? '', $keepFragment, $useLowercase);
     }
 
     public function getRelativeTargetUrl(): ParsedUrl
@@ -283,9 +289,10 @@ class OfflineUrlConverter
      *
      * @param string $filePath
      * @param bool $keepFragment
+     * @param bool $lowercase
      * @return string
      */
-    public static function sanitizeFilePath(string $filePath, bool $keepFragment): string
+    public static function sanitizeFilePath(string $filePath, bool $keepFragment, bool $lowercase = false): string
     {
         // First decode URL-encoded characters to get proper UTF-8 characters
         // This converts %C3%BC to ü, %C3%B6 to ö, %E4%B8%AD to 中, etc.
@@ -303,7 +310,12 @@ class OfflineUrlConverter
 
             if (is_string($queryString) && trim($queryString) !== '') {
                 $queryHash = self::getQueryHashFromQueryString($queryString);
-                $filePath = $start . '.' . $queryHash . '.' . $extension;
+                // Only add query hash to filename if it's not empty after processing
+                if ($queryHash !== null && trim($queryHash) !== '') {
+                    $filePath = $start . '.' . $queryHash . '.' . $extension;
+                } else {
+                    $filePath = $start . '.' . $extension;
+                }
 
                 // add fragment to the end of the file path
                 if ($keepFragment && $fragment) {
@@ -382,6 +394,11 @@ class OfflineUrlConverter
             $filePath = preg_replace('/#.+$/', '', $filePath);
         }
 
+        // Convert to lowercase if requested
+        if ($lowercase) {
+            $filePath = strtolower($filePath);
+        }
+
         return $filePath;
     }
 
@@ -392,6 +409,15 @@ class OfflineUrlConverter
     public static function setReplaceQueryString(array $replaceQueryString): void
     {
         self::$replaceQueryString = $replaceQueryString;
+    }
+
+    /**
+     * @param bool $lowercase
+     * @return void
+     */
+    public static function setLowercase(bool $lowercase): void
+    {
+        self::$lowercase = $lowercase;
     }
 
     /**

--- a/tests/OfflineUrlConverterTest.php
+++ b/tests/OfflineUrlConverterTest.php
@@ -127,6 +127,42 @@ class OfflineUrlConverterTest extends TestCase
     }
 
     /**
+     * Test sanitizeFilePath with lowercase option
+     */
+    public function testSanitizeFilePathWithLowercase()
+    {
+        $testCases = [
+            ['Test/File.HTML', 'test/file.html'],
+            ['UPPERCASE/PATH.CSS', 'uppercase/path.css'],
+            ['MixedCase/File.JS', 'mixedcase/file.js'],
+            ['Special-Characters_File.PNG', 'special-characters_file.png'],
+            ['path/with/MULTIPLE/LEVELS.txt', 'path/with/multiple/levels.txt'],
+        ];
+
+        foreach ($testCases as [$input, $expected]) {
+            $result = OfflineUrlConverter::sanitizeFilePath($input, false, true);
+            $this->assertEquals($expected, $result, "Failed for input: $input");
+        }
+    }
+
+    /**
+     * Test sanitizeFilePath without lowercase option (should remain unchanged)
+     */
+    public function testSanitizeFilePathWithoutLowercase()
+    {
+        $testCases = [
+            ['Test/File.HTML', 'Test/File.HTML'],
+            ['UPPERCASE/PATH.CSS', 'UPPERCASE/PATH.CSS'],
+            ['MixedCase/File.JS', 'MixedCase/File.JS'],
+        ];
+
+        foreach ($testCases as [$input, $expected]) {
+            $result = OfflineUrlConverter::sanitizeFilePath($input, false, false);
+            $this->assertEquals($expected, $result, "Failed for input: $input");
+        }
+    }
+
+    /**
      * @return array[]
      */
     public static function utf8FilePathProvider(): array


### PR DESCRIPTION
I was attempting to submit this individually, but it has become a lot of work and I need this for a site I am archiving, so for now I am creating a single PR with all of what I am working with so you can peek and see the direction I am taking and send over any feedback.

This is the things I've been working on:

Major things:

- Major regex rework:  I found the whole regex a bit weak to support the three double quote, single quote and no quote alternatives of most parsings. So:
  -  I refactored this into a single function that performs the regex individually on all three cases. This allows me to do custom bits like allowing spaces when quoted and not allowing spaces without them.
  - I worked this out using a pseudo-template-regex language where a single regex can be used for all three cases. 
  - This allowed me also to add some "macros" to the language so regex partials can be easilly reused.

Minor things:

- With `--replace-query-string="/.*/ -> " \` the files were downloaded with `..css`, now if the query string is empty is `.css`.
- Added `--offline-export-lowercase` so that everything is converted to lowercase. 
