### PR TITLE
Add support for lazyloadjs images using [data-src]

### DIFF
--- a/src/Crawler/ContentProcessor/HtmlProcessor.php
+++ b/src/Crawler/ContentProcessor/HtmlProcessor.php
@@ -286,6 +286,10 @@ class HtmlProcessor extends BaseProcessor implements ContentProcessor
         preg_match_all('/<img\s+[^>]*?src=["\']?([^"\'> ]+)["\']?[^>]*>/is', $html, $matches);
         $foundUrls->addUrlsFromTextArray($matches[1], $sourceUrlWithoutFragment, FoundUrl::SOURCE_IMG_SRC);
 
+        // <img data-src="..." (lazy loading js libraries)
+        preg_match_all('/<img\s+[^>]*?data-src=["\']?([^"\'> ]+)["\']?[^>]*>/is', $html, $matches);
+        $foundUrls->addUrlsFromTextArray($matches[1], $sourceUrlWithoutFragment, FoundUrl::SOURCE_IMG_SRC);
+
         // <input src="..."
         preg_match_all('/<input\s+[^>]*?src=["\']?([^"\'> ]+\.[a-z0-9]{1,10})["\']?[^>]*>/is', $html, $matches);
         $foundUrls->addUrlsFromTextArray($matches[1], $sourceUrlWithoutFragment, FoundUrl::SOURCE_INPUT_SRC);


### PR DESCRIPTION
I need to export a site that uses lazyloadjs, which means all images use `data-src` instead of `src`. This adds support to download those images.