### PR TITLE
fix query params for astro images

### DIFF
--- a/src/Crawler/ContentProcessor/HtmlProcessor.php
+++ b/src/Crawler/ContentProcessor/HtmlProcessor.php
@@ -153,7 +153,7 @@ class HtmlProcessor extends BaseProcessor implements ContentProcessor
             $attributeRaw = $matches[2];
             $assignmentChar = $matches[3];
             $quote = $matches[4];
-            $value = $matches[5];
+            $value = html_entity_decode($matches[5], ENT_QUOTES | ENT_HTML5);
             $end = $matches[6];
 
             // when modifying x.src (JS) and there is no quote, we do not convert, because it is not a valid URL but JS code


### PR DESCRIPTION
Image URL's like this:

`<img src="/_image?href=%2F_astro%2Flogo.I81FHMZt.svg&amp;w=215&amp;h=40&amp;f=svg">`

were getting proper filenames:

'_image.01662772d3.svg'

but not properly converted to HTML:

'<img src="/_image?href=%2F_astro%2Flogo.I81FHMZt.svg&#38;w=215&#38;h=40&#38;f=svg">`