### PR TITLE
feat: add --url-list to crawl a bounded set of URLs from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ GIF animation of the crawler in action (also available as a [▶️ video](https
 - [▶️ Usage](#️-usage)
     * [Interactive wizard](#interactive-wizard)
     * [Basic example](#basic-example)
+    * [URL list example](#url-list-example)
     * [CI/CD example](#cicd-example)
     * [Fully-featured example](#fully-featured-example)
     * [⚙️ Arguments](#️-arguments)
@@ -106,6 +107,9 @@ The following features are summarized in greater detail:
   which will be processed as a list of URLs. In sitemap-only mode, the crawler follows only URLs from
   the sitemap — it does not discover additional links from HTML pages. Gzip-compressed sitemaps (`*.xml.gz`)
   are fully supported, both as direct URLs and when referenced from sitemap index files.
+- with `--url-list=<file>` you can crawl a **bounded list of URLs** from a plain-text file (one URL per line).
+  The first URL in the file becomes the crawl base when `--url` is omitted. Combine it with `--single-page`
+  to crawl exactly the listed URLs without discovering additional links.
 - respects the HTML `<base href>` tag when resolving relative URLs on pages that use it.
 
 ### 🛠️ Dev/DevOps assistant
@@ -364,6 +368,15 @@ To run the crawler from the command line, provide the required arguments:
 ./siteone-crawler --url=https://mydomain.tld/ --device=mobile
 ```
 
+### URL list example
+
+Crawl exactly a bounded set of URLs listed in a file, without following any discovered links:
+
+```bash
+# urls.txt — one URL per line, blank lines and '#' comments ignored
+./siteone-crawler --url-list=urls.txt --single-page
+```
+
 ### CI/CD example
 
 ```bash
@@ -445,7 +458,8 @@ For a clearer list, I recommend going to the documentation: 🌐 https://crawler
 
 | Parameter | Description |
 |-----------|-------------|
-| `--url=<url>` | Required. HTTP or HTTPS URL address of the website or sitemap xml to be crawled.<br>Use quotation marks `''` if the URL contains query parameters. |
+| `--url=<url>` | Required (unless `--url-list` is used). HTTP or HTTPS URL address of the website or sitemap xml<br>to be crawled. Use quotation marks `''` if the URL contains query parameters. |
+| `--url-list=<file>` | Path to a plain-text file with one URL per line (blank lines and `#` comments are ignored).<br>When provided, `--url` is optional and the first URL in the file is used as the crawl base.<br>All listed URLs are seeded into the crawl queue. Combine with `--single-page` to crawl<br>exactly the listed URLs without following any discovered links.<br>Listed URLs are crawled directly: `robots.txt` and `--include-regex`/`--ignore-regex` do not apply to them. |
 | `--single-page` | Load only one page to which the URL is given (and its assets), but do not follow other pages. |
 | `--max-depth=<int>` | Maximum crawling depth (for pages, not assets). Default is `0` (no limit). `1` means `/about`<br>or `/about/`, `2` means `/about/contacts` etc. |
 | `--device=<val>` | Device type for choosing a predefined User-Agent. Ignored when `--user-agent` is defined.<br>Supported values: `desktop`, `mobile`, `tablet`. Default is `desktop`. |

--- a/src/engine/crawler.rs
+++ b/src/engine/crawler.rs
@@ -216,6 +216,12 @@ impl Crawler {
         // Add initial URL to queue
         self.add_url_to_queue(&self.initial_parsed_url.clone(), None, UrlSource::InitUrl as i32);
 
+        // Seed additional URLs from --url-list (dedup is handled by the queue's URL key).
+        for url_str in &self.options.url_list_urls {
+            let parsed = ParsedUrl::parse(url_str, None);
+            self.add_url_to_queue(&parsed, None, UrlSource::UrlList as i32);
+        }
+
         // Print table header
         if let Ok(mut output) = self.output.lock() {
             output.add_table_header();

--- a/src/engine/found_url.rs
+++ b/src/engine/found_url.rs
@@ -25,6 +25,7 @@ pub enum UrlSource {
     JsUrl = 70,
     Redirect = 80,
     Sitemap = 90,
+    UrlList = 91,
 }
 
 impl UrlSource {
@@ -46,6 +47,7 @@ impl UrlSource {
             UrlSource::JsUrl => "js url",
             UrlSource::Redirect => "redirect",
             UrlSource::Sitemap => "sitemap",
+            UrlSource::UrlList => "url list",
         }
     }
 
@@ -67,6 +69,7 @@ impl UrlSource {
             70 => Some(UrlSource::JsUrl),
             80 => Some(UrlSource::Redirect),
             90 => Some(UrlSource::Sitemap),
+            91 => Some(UrlSource::UrlList),
             _ => None,
         }
     }

--- a/src/options/core_options.rs
+++ b/src/options/core_options.rs
@@ -517,7 +517,7 @@ impl CoreOptions {
         // Validate required fields
         if core.url.is_empty() {
             return Err(CrawlerError::Config(
-                "Invalid or undefined --url parameter.".to_string(),
+                "Invalid or undefined input. Provide --url=<url> or --url-list=<file>.".to_string(),
             ));
         }
         if core.workers < 1 {

--- a/src/options/core_options.rs
+++ b/src/options/core_options.rs
@@ -64,6 +64,8 @@ impl StorageType {
 pub struct CoreOptions {
     // basic settings
     pub url: String,
+    pub url_list: Option<String>,
+    pub url_list_urls: Vec<String>,
     pub single_page: bool,
     pub max_depth: i64,
     pub device: DeviceType,
@@ -244,6 +246,8 @@ impl CoreOptions {
         let mut core = CoreOptions {
             // basic settings
             url: String::new(),
+            url_list: None,
+            url_list_urls: Vec::new(),
             single_page: false,
             max_depth: 0,
             device: DeviceType::Desktop,
@@ -486,6 +490,30 @@ impl CoreOptions {
             return Ok(core);
         }
 
+        // Process --url-list: read & parse the file, then optionally use the first
+        // URL as the crawl base when --url was not provided.
+        if let Some(ref path) = core.url_list {
+            if !std::path::Path::new(path).is_file() {
+                return Err(CrawlerError::Config(format!(
+                    "URL list file '{}' does not exist or is not a file.",
+                    path
+                )));
+            }
+            let content = std::fs::read_to_string(path)
+                .map_err(|e| CrawlerError::Config(format!("Cannot read URL list file '{}': {}", path, e)))?;
+            let urls = parse_line_list(&content);
+            if urls.is_empty() {
+                return Err(CrawlerError::Config(format!(
+                    "URL list file '{}' contains no URLs (empty list).",
+                    path
+                )));
+            }
+            if core.url.is_empty() {
+                core.url = urls[0].clone();
+            }
+            core.url_list_urls = urls;
+        }
+
         // Validate required fields
         if core.url.is_empty() {
             return Err(CrawlerError::Config(
@@ -523,6 +551,11 @@ impl CoreOptions {
             "url" => {
                 if let Some(s) = value.as_str() {
                     self.url = s.to_string();
+                }
+            }
+            "urlList" => {
+                if let Some(s) = value.as_str() {
+                    self.url_list = Some(s.to_string());
                 }
             }
             "singlePage" => {
@@ -1295,6 +1328,11 @@ pub fn get_options() -> Options {
             CrawlerOption::new(
                 "--url", Some("-u"), "url", OptionType::Url, false,
                 "Required URL. It can also be the URL to sitemap.xml. Enclose in quotes if URL contains query parameters.",
+                None, true, false, None,
+            ),
+            CrawlerOption::new(
+                "--url-list", None, "urlList", OptionType::String, false,
+                "Path to a plain-text file with one URL per line (blank lines and `#` comments ignored). When provided, --url is optional; the first URL in the file is used as the crawl base. All listed URLs are seeded into the crawl queue.",
                 None, true, false, None,
             ),
             CrawlerOption::new(
@@ -2396,13 +2434,22 @@ pub fn get_options() -> Options {
 fn read_config_file(path: &str) -> Result<Vec<String>, CrawlerError> {
     let content = std::fs::read_to_string(path)
         .map_err(|e| CrawlerError::Config(format!("Cannot read config file '{}': {}", path, e)))?;
-    let args: Vec<String> = content
+    Ok(parse_line_list(&content))
+}
+
+/// Parse a newline-delimited list (config files, --url-list): trim each line,
+/// drop blank lines and `#` comments. A leading UTF-8 BOM is stripped first —
+/// it is not whitespace, so `trim()` would leave it on the first entry and
+/// corrupt it (common in files saved on Windows).
+fn parse_line_list(content: &str) -> Vec<String> {
+    content
+        .strip_prefix('\u{feff}')
+        .unwrap_or(content)
         .lines()
         .map(|line| line.trim())
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .map(|line| line.to_string())
-        .collect();
-    Ok(args)
+        .collect()
 }
 
 /// Load config from file: --config-file=PATH, ~/.siteone-crawler.conf, or /etc/siteone-crawler.conf.
@@ -2692,6 +2739,8 @@ mod tests {
     fn make_default_core_options() -> CoreOptions {
         CoreOptions {
             url: "https://test.com".to_string(),
+            url_list: None,
+            url_list_urls: Vec::new(),
             single_page: false,
             max_depth: 0,
             device: DeviceType::Desktop,
@@ -2850,6 +2899,14 @@ mod tests {
     }
 
     #[test]
+    fn apply_url_list_string() {
+        let mut opts = make_default_core_options();
+        opts.apply_option_value("urlList", &OptionValue::Str("urls.txt".into()))
+            .unwrap();
+        assert_eq!(opts.url_list, Some("urls.txt".to_string()));
+    }
+
+    #[test]
     fn apply_ci_min_score() {
         let mut opts = make_default_core_options();
         opts.apply_option_value("ciMinScore", &OptionValue::Float(7.5)).unwrap();
@@ -2949,6 +3006,21 @@ mod tests {
     fn read_config_file_nonexistent_returns_error() {
         let result = read_config_file("/nonexistent/path/config.conf");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_line_list_strips_leading_bom() {
+        // A UTF-8 BOM at the start must not leak into the first entry.
+        let content = "\u{feff}https://example.com/\nhttps://example.com/about\n";
+        let urls = parse_line_list(content);
+        assert_eq!(urls, vec!["https://example.com/", "https://example.com/about"]);
+    }
+
+    #[test]
+    fn parse_line_list_trims_and_filters() {
+        let content = "# comment\n\n  https://a.test/  \n  # indented comment\n  \nhttps://b.test/\n";
+        let urls = parse_line_list(content);
+        assert_eq!(urls, vec!["https://a.test/", "https://b.test/"]);
     }
 
     #[test]

--- a/src/scoring/ci_gate.rs
+++ b/src/scoring/ci_gate.rs
@@ -195,6 +195,8 @@ mod tests {
     fn make_options() -> CoreOptions {
         CoreOptions {
             url: "https://test.com".to_string(),
+            url_list: None,
+            url_list_urls: Vec::new(),
             single_page: false,
             max_depth: 0,
             device: crate::types::DeviceType::Desktop,

--- a/tests/integration_crawl.rs
+++ b/tests/integration_crawl.rs
@@ -670,3 +670,76 @@ fn html_to_markdown_with_move_before_h1() {
     );
     assert!(stdout.contains("Page body"));
 }
+
+// =========================================================================
+// --url-list: crawl a bounded set of URLs from a file
+// =========================================================================
+
+#[test]
+fn url_list_nonexistent_file_exits_with_101() {
+    let output = run_crawler(&["--url-list=/nonexistent/path/urls.txt"]);
+    assert_eq!(
+        output.status.code(),
+        Some(101),
+        "Expected exit code 101 for nonexistent URL list file"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("/nonexistent/path/urls.txt"),
+        "Error should mention the file path, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn url_list_empty_file_exits_with_101() {
+    let tmp = TempDir::new("url-list-empty");
+    let list_path = tmp.path.join("urls.txt");
+    // Only blank lines and comments — no actual URLs.
+    std::fs::write(&list_path, "\n# just a comment\n\n   \n").unwrap();
+
+    let output = run_crawler(&[&format!("--url-list={}", list_path.display())]);
+    assert_eq!(
+        output.status.code(),
+        Some(101),
+        "Expected exit code 101 for empty URL list file"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("empty list") || stderr.contains("no URLs"),
+        "Error should mention empty list, got: {}",
+        stderr
+    );
+}
+
+#[test]
+#[ignore]
+fn url_list_crawls_listed_urls() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+
+    let tmp = TempDir::new("url-list-crawl");
+    let list_path = tmp.path.join("urls.txt");
+    std::fs::write(
+        &list_path,
+        "# two known HTML pages on crawler.siteone.io\n\
+         https://crawler.siteone.io/\n\
+         https://crawler.siteone.io/introduction/overview/\n",
+    )
+    .unwrap();
+
+    let list_arg = format!("--url-list={}", list_path.display());
+    let mut args: Vec<&str> = vec![&list_arg, "--single-page", "--disable-all-assets", "--output=json"];
+    args.extend_from_slice(&GENTLE_FLAGS);
+    let json = run_crawler_json(&args);
+
+    // With --single-page and assets disabled, exactly the 2 listed HTML pages are crawled.
+    let total_urls = json["stats"]["totalUrls"].as_i64().expect("totalUrls");
+    assert_eq!(total_urls, 2, "Expected exactly 2 crawled URLs, got {}", total_urls);
+
+    let count_200 = json["stats"]["countByStatus"]
+        .as_object()
+        .and_then(|m| m.get("200"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+    assert_eq!(count_200, 2, "Expected 2 successful pages, got {}", count_200);
+}


### PR DESCRIPTION
Hello,

This adds an new option, `--url-list=<file>`, so you can point the crawler at a fixed list of URLs instead of discovery only.

Notes:
- `--url` becomes optional, the first URL in the file is used as the base.
- If we combine with `--single-page`, we only crawl exactly the listed URLs (and their assets).
- Listed URLs are excluded from `robots.txt` / `--include-regex` / `--ignore-regex` filtering.
- Line from the file starting with `#` are ignored.

> :warning: I'm not a Rust developer: this change was co-authored by Claude Code.
